### PR TITLE
Fix image paths for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
 
     <!--NavBar-->
     <nav>
-        <a href="../index.html">
-            <img src="../img/logo.svg" alt="logo_picture">
+        <a href="index.html">
+            <img src="img/logo.svg" alt="logo_picture">
         </a>
         
         <ul>

--- a/products.json
+++ b/products.json
@@ -9,7 +9,7 @@
     "peso": "68 kg",
     "detalleUrl": "#",
     "capacidad": "6 compartimentos interiores",
-    "imagen": "../img/Aparador Uspallata.png"
+    "imagen": "img/Aparador Uspallata.png"
   },
   {
     "id": 2,
@@ -20,7 +20,7 @@
     "acabado": "Laca mate ecológica",
     "capacidad": "5 estantes ajustables",
     "detalleUrl": "#",
-    "imagen": "../img/Biblioteca Recoleta.png"
+    "imagen": "img/Biblioteca Recoleta.png"
   },
   {
     "id": 3,
@@ -31,7 +31,7 @@
     "acabado": "Cera vegetal, tapizado premium repelente al agua y manchas",
     "confort": "Espuma de alta densidad",
     "detalleUrl": "#",
-    "imagen": "../img/Butaca Mendoza.png"
+    "imagen": "img/Butaca Mendoza.png"
   },
   {
     "id": 4,
@@ -43,7 +43,7 @@
     "rotacion": "360° silenciosa y suave",
     "garantia": "10 años en estructura",
     "detalleUrl": "#",
-    "imagen": "../img/Sillón Copacabana.png"
+    "imagen": "img/Sillón Copacabana.png"
   },
   {
     "id": 5,
@@ -55,7 +55,7 @@
     "peso": "42 kg (25 kg en superficie)",
     "cargaMaxima": "25 kg distribuidos",
     "detalleUrl": "#",
-    "imagen": "../img/Mesa de Centro Araucaria.png"
+    "imagen": "img/Mesa de Centro Araucaria.png"
   },
   {
     "id": 6,
@@ -66,7 +66,7 @@
     "acabado": "Barniz mate de poliuretano",
     "almacenamiento": "1 cajón + repisa inferior, cierre suave",
     "detalleUrl": "#",
-    "imagen": "../img/Mesa de Noche Aconcagua.png"
+    "imagen": "img/Mesa de Noche Aconcagua.png"
   },
   {
     "id": 7,
@@ -77,7 +77,7 @@
     "acabado": "Aceite natural, tapizado premium",
     "caracteristicas": "Compatible con colchón 160×200, cabecero acolchado",
     "detalleUrl": "#",
-    "imagen": "../img/banner.png"
+    "imagen": "img/banner.png"
   },
   {
     "id": 8,
@@ -88,7 +88,7 @@
     "acabado": "Espuma HR + plumón reciclado",
     "sostenibilidad": "Materiales 100% reciclables",
     "detalleUrl": "#",
-    "imagen": "../img/Sofá Patagonia.png"
+    "imagen": "img/Sofá Patagonia.png"
   },
   {
     "id": 9,
@@ -99,7 +99,7 @@
     "acabado": "Aceite-cera natural",
     "capacidad": "6-10 comensales",
     "detalleUrl": "#",
-    "imagen": "../img/Mesa Comedor Pampa.png"
+    "imagen": "img/Mesa Comedor Pampa.png"
   },
   {
     "id": 10,
@@ -110,7 +110,7 @@
     "acabado": "Laca mate, pintura epoxi",
     "incluye": "Set de 4 sillas apilables",
     "detalleUrl": "#",
-    "imagen": "../img/Sillas Córdoba.png"
+    "imagen": "img/Sillas Córdoba.png"
   },
   {
     "id": 11,
@@ -121,7 +121,7 @@
     "acabado": "Laca mate resistente",
     "almacenamiento": "1 cajón con organizador, pasacables integrado",
     "detalleUrl": "#",
-    "imagen": "../img/Escritorio Costa.png"
+    "imagen": "img/Escritorio Costa.png"
   },
   {
     "id": 12,
@@ -132,6 +132,6 @@
     "acabado": "Tapizado premium",
     "regulacion": "Altura e inclinación respaldo, certificación EN 1335",
     "detalleUrl": "#",
-    "imagen": "../img/Silla de Trabajo Belgrano.png"
+    "imagen": "img/Silla de Trabajo Belgrano.png"
   }
 ]


### PR DESCRIPTION
## Summary
- Correct relative path to logo in index nav so it works on GitHub Pages
- Replace `../img` references with `img` in index.html and products.json

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be2d652f608331842ef413381afb5b